### PR TITLE
Bug/clearSelectedItems doesn't clear a storage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 * In general follow (https://docs.npmjs.com/getting-started/semantic-versioning) versioning.
 
 ## <next>
+* Fixed a bug: when clearSelectedItems action called, it doesn't change saved selected items in a session storage
 
 ## 5.1.1
 * Add translation for search tooltip

--- a/src/datagrid/datagrid.utils.js
+++ b/src/datagrid/datagrid.utils.js
@@ -239,8 +239,7 @@ export default {
   },
   saveSelectedItems: (grid, selectedItems) => {
     if (grid.disableRememberSelectedItems) return false;
-    if (!selectedItems) return false;
-    sessionStorage.setItem(`oc_grid_selectedItems_${grid.id}`, JSON.stringify(selectedItems));
+    sessionStorage.setItem(`oc_grid_selectedItems_${grid.id}`, JSON.stringify(selectedItems || []));
     return true;
   },
   saveColumnWidths: (grid, columnWidths) => {


### PR DESCRIPTION
Fixed a bug: when clearSelectedItems action called, it doesn't change saved selected items in a session storage