### PR TITLE
Fixed :before color-corner shown only for grid cells, not for action …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 * In general follow (https://docs.npmjs.com/getting-started/semantic-versioning) versioning.
 
 ## <next>
+* Fixed :before color-corner shown only for grid cells, not for action bar items 
 
 ## 5.1.3
 * Fixed a bug: renamed passed CellTooltip prop messageId->infoMessage  

--- a/src/datagrid/datagrid.component.scss
+++ b/src/datagrid/datagrid.component.scss
@@ -166,7 +166,7 @@
   }
 
   // CELL MESSAGES
-  .oc-datagrid-tooltip {
+  .oc-datagrid-main-container .oc-datagrid-tooltip {
     position: static;
     &.info {
       &:before {


### PR DESCRIPTION
…bar items