### PR TITLE
filterMatcher changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 * In general follow (https://docs.npmjs.com/getting-started/semantic-versioning) versioning.
 
 ## <next>
+* Changed `filterMatcher` parameters: it will now receive rowData and a filterValue. This is a breaking change.
 
 ## 5.7.0
 * Fixed issue #60: First day of the week is Su always

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ Also you need to configure sass loader, since all the styles are in sass format.
 | valueEmptyChecker          | function       |         | Checker function defined when data is empty |
 | sortValueGetter            | function       |         | Getter function for the sort data        |
 | sortComparator             | function       |         | Comparator function for the sort data    |
-| filterMatcher              | function       |         | Matcher function that matches filter to data |
+| filterMatcher              | function       |         | Matcher function that matches filter to data (parameters: rowData, filterValue) |
 | defaultValue               | string, number |         | Default value for the item when creating new item |
 | isRequired                 | bool           |         | Indicating if column value is required   |
 | onValueMatchChangeValue    | object         |         | Change other column value if own value matches |

--- a/src/datagrid/datagrid.actions.js
+++ b/src/datagrid/datagrid.actions.js
@@ -107,10 +107,10 @@ export const applyFilters = (grid, columns) =>
         filterData.forEach((filterValue, filterColumn) => {
           columns.forEach((column) => {
             if (Utils.getColumnKey(column) === filterColumn) {
-              const rowData = row.getIn(column.valueKeyPath);
-              if (rowData || rowData === 0 || rowData === false) {
+              const value = row.getIn(column.valueKeyPath);
+              if (value || value === 0 || value === false) {
                 const filterMatcher = Utils.getFilterMatcher(column, dateFormat);
-                if (filterMatcher(rowData, filterValue)) {
+                if (filterMatcher(row, filterValue)) {
                   hits += 1;
                 }
               }

--- a/src/datagrid/datagrid.utils.js
+++ b/src/datagrid/datagrid.utils.js
@@ -114,28 +114,29 @@ export default {
     }
   },
   getFilterMatcher: (col, dateFormat) => {
-    if (col.filterMatcher) {
-      return col.filterMatcher;
-    }
+
+    if (col.filterMatcher) return col.filterMatcher;
+    const getVal = row => row.getIn(col.valueKeyPath);
+
     switch (col.valueType) {
       case 'number':
-        return (val, filterVal) => parseInt(val, 10) === parseInt(filterVal, 10);
+        return (row, filterVal) => parseInt(getVal(row), 10) === parseInt(filterVal, 10);
       case 'float':
       case 'currency':
-        return (val, filterVal) => parseFloat(filterVal.replace(',', '.')) === val;
+        return (row, filterVal) => parseFloat(filterVal.replace(',', '.')) === getVal(row);
       case 'date':
-        return (val, filterVal) => {
-          if (moment(val).isValid()) {
-            return moment(val).format(dateFormat) === moment(filterVal).format(dateFormat);
+        return (row, filterVal) => {
+          if (moment(getVal(row)).isValid()) {
+            return moment(getVal(row)).format(dateFormat) === moment(filterVal).format(dateFormat);
           }
           return false;
         };
       case 'boolean':
       case 'select':
-        return (val, filterVal) => val === filterVal;
+        return (row, filterVal) => getVal(row) === filterVal;
       case 'text':
       default:
-        return (val, filterVal) => (new RegExp(filterVal, 'i')).test(val);
+        return (row, filterVal) => (new RegExp(filterVal, 'i')).test(getVal(row));
     }
   },
   loadSelectedItems: (grid) => {

--- a/src/datagrid/datagrid.utils.js
+++ b/src/datagrid/datagrid.utils.js
@@ -114,7 +114,6 @@ export default {
     }
   },
   getFilterMatcher: (col, dateFormat) => {
-
     if (col.filterMatcher) return col.filterMatcher;
     const getVal = row => row.getIn(col.valueKeyPath);
 


### PR DESCRIPTION
* filterMatcher used to receive a cell value as a first parameter and a filterValue as a 2nd parameter. I changed the applyFilters function in datagrid.actions.js --> filterMatcher's 1st parameter will now be a row object (Immutable Map)
* changed getFilterMatcher fn in datagrid.utils.js so that the default filtering continues to operate the way it used to
* This PR contains breaking changes, so I'll publish a new major version after merging