### PR TITLE
Save pagination page also when it is set via the action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 
 ## <next>
 
+## 7.3.12
+* Fixed pagination page being overridden from session store after calling setPaginationPage 
+
 ## 7.3.11
 * Upgrade `@opuscapita/react-datetime` and other components
 

--- a/src/datagrid/datagrid.actions.js
+++ b/src/datagrid/datagrid.actions.js
@@ -873,6 +873,7 @@ export const saveColumnSettings = (grid, hiddenColumns, columnOrder) => (dispatc
 };
 
 export const setPaginationPage = (grid, paginationPage) => (dispatch) => {
+  Utils.savePaginationPage(grid, { page: paginationPage });
   dispatch({
     paginationPage,
     id: grid.id,

--- a/src/datagrid/pagination.component.jsx
+++ b/src/datagrid/pagination.component.jsx
@@ -104,7 +104,6 @@ const paginationComponent = (WrappedComponent) => {
     gotoPage = (page) => {
       const { grid } = this.props;
       this.props.setPaginationPage(grid, page);
-      Utils.savePaginationPage(grid, { page });
     }
 
     render = () => {


### PR DESCRIPTION
If one has a paginated grid where the current page is not the first one and then the host app tries to return the grid to the first page by calling setPaginationPage action (for example when it wants to reload whole data from the beginning) then the grid returns to the first page briefly but immediately bounces back to the page where it was before calling the action. This seems to happen because pagination component saves the current page to sessions store when user changes the page but the action does not and the value coming from session store overrides what the action tried to set. Looks like it it can be fixed by moving Utils.savePaginationPage call from pagination component to the action.