### PR TITLE
Prevented one unnecessary paginated grid rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 * In general follow (https://docs.npmjs.com/getting-started/semantic-versioning) versioning.
 
 ## <next>
+* Prevent paginated grid rendering after data is requested and response is not yet received
 
 ## 8.3.3
 * Fixed immutable convertion of filterData: nested array type of property is converted to immutable list

--- a/src/datagrid/datagrid.actions.js
+++ b/src/datagrid/datagrid.actions.js
@@ -187,10 +187,10 @@ export const applySort = (grid, columns) => (dispatch, getState) => {
   });
   if (!column) return false;
 
+  setBusy(grid)(dispatch);
   if (grid.pagination) {
     return true;
   }
-  setBusy(grid)(dispatch);
 
   const origAllData = gridData.get('allData');
   const comparator = Utils.getSortComparator(column);
@@ -892,6 +892,7 @@ export const saveColumnSettings = (grid, hiddenColumns, columnOrder) => (dispatc
 };
 
 export const setPage = (grid, page) => (dispatch) => {
+  setBusy(grid)(dispatch);
   Utils.savePage(grid, page);
   dispatch({
     page,
@@ -901,6 +902,7 @@ export const setPage = (grid, page) => (dispatch) => {
 };
 
 export const setRowsOnPage = (grid, rowsOnPage) => (dispatch) => {
+  setBusy(grid)(dispatch);
   Utils.saveRowsOnPage(grid, rowsOnPage);
   dispatch({
     rowsOnPage,

--- a/src/datagrid/datagrid.component.jsx
+++ b/src/datagrid/datagrid.component.jsx
@@ -1300,6 +1300,7 @@ class DataGrid extends React.PureComponent {
         {this.state.contextMenuOpen && this.renderContextMenu()}
         {actionBar}
         <ResponsiveFixedDataTable
+          {...this.props}
           id={this.props.grid.id}
           rowsCount={rowsCount}
           headerHeight={

--- a/src/datagrid/responsive-fixed-data-table.component.jsx
+++ b/src/datagrid/responsive-fixed-data-table.component.jsx
@@ -1,6 +1,7 @@
 /* eslint-disable react/forbid-prop-types, react/no-find-dom-node */
 import React from 'react';
 import PropTypes from 'prop-types';
+import ImmutablePropTypes from 'react-immutable-proptypes';
 import { findDOMNode } from 'react-dom';
 import { Table } from 'fixed-data-table-2';
 import debounce from 'lodash/debounce';
@@ -12,11 +13,23 @@ export default class ResponsiveFixedDataTable extends React.Component {
   static propTypes = {
     containerStyle: PropTypes.object,
     refreshRate: PropTypes.number,
+    filterData: ImmutablePropTypes.map,
+    page: PropTypes.number,
+    pagination: PropTypes.shape({}),
+    rowsOnPage: PropTypes.number,
+    sortColumn: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+    sortOrder: PropTypes.string,
   };
 
   static defaultProps = {
     containerStyle: {},
     refreshRate: 250, // ms
+    filterData: undefined,
+    page: undefined,
+    pagination: undefined,
+    rowsOnPage: undefined,
+    sortColumn: undefined,
+    sortOrder: undefined,
   };
 
   state = {
@@ -37,6 +50,28 @@ export default class ResponsiveFixedDataTable extends React.Component {
   }
 
   shouldComponentUpdate(nextProps, nextState) {
+    const {
+      filterData,
+      page,
+      pagination,
+      rowsOnPage,
+      sortColumn,
+      sortOrder,
+    } = this.props;
+    const {
+      filterData: prevFilterData,
+      page: prevPage,
+      rowsOnPage: prevRowsOnPage,
+      sortColumn: nextSortColumn,
+      sortOrder: nextSortOrder,
+    } = nextProps;
+    if (pagination && (sortColumn !== nextSortColumn
+      || sortOrder !== nextSortOrder
+      || (filterData && !filterData.equals(prevFilterData))
+      || page !== prevPage
+      || rowsOnPage !== prevRowsOnPage)) {
+      return false;
+    }
     return !isEqual(this.props, nextProps) || !isEqual(this.state, nextState);
   }
 
@@ -76,7 +111,6 @@ export default class ResponsiveFixedDataTable extends React.Component {
 
   render() {
     const { gridWidth, gridHeight } = this.state;
-
     return (
       <div className="oc-datagrid-main-container" style={this.getStyle()}>
         <Table {...this.props} width={gridWidth} height={gridHeight} />

--- a/src/datagrid/responsive-fixed-data-table.component.jsx
+++ b/src/datagrid/responsive-fixed-data-table.component.jsx
@@ -111,6 +111,7 @@ export default class ResponsiveFixedDataTable extends React.Component {
 
   render() {
     const { gridWidth, gridHeight } = this.state;
+
     return (
       <div className="oc-datagrid-main-container" style={this.getStyle()}>
         <Table {...this.props} width={gridWidth} height={gridHeight} />

--- a/test/datagrid/datagrid.actions.spec.js
+++ b/test/datagrid/datagrid.actions.spec.js
@@ -839,26 +839,41 @@ describe('Datagrid actions', () => {
   it('set page', function () {
     const page = 3;
     const action = actions.setPage(GRID, page);
-    const expectedAction = {
-      page,
-      id: GRID.id,
-      type: actions.TYPES.PLATFORM_DATAGRID_SET_PAGE,
-    };
+    const expectedActions = [
+      {
+        type: actions.TYPES.PLATFORM_DATAGRID_BUSY,
+        id: GRID.id,
+      },
+      {
+        page,
+        id: GRID.id,
+        type: actions.TYPES.PLATFORM_DATAGRID_SET_PAGE,
+      },
+    ];
 
     this.store.dispatch(action);
-    expect(this.store.getActions()[0]).to.eql(expectedAction);
+    expect(this.store.getActions()[0]).to.eql(expectedActions[0]);
+    expect(this.store.getActions()[1]).to.eql(expectedActions[1]);
   });
 
   it('set rows on page', function () {
     const rowsOnPage = 50;
     const action = actions.setRowsOnPage(GRID, rowsOnPage);
-    const expectedAction = {
-      rowsOnPage,
-      id: GRID.id,
-      type: actions.TYPES.PLATFORM_DATAGRID_SET_ROWS_ON_PAGE,
-    };
+    const expectedActions = [
+      {
+        type: actions.TYPES.PLATFORM_DATAGRID_BUSY,
+        id: GRID.id,
+      },
+      {
+        rowsOnPage,
+        id: GRID.id,
+        type: actions.TYPES.PLATFORM_DATAGRID_SET_ROWS_ON_PAGE,
+      },
+    ];
 
     this.store.dispatch(action);
-    expect(this.store.getActions()[0]).to.eql(expectedAction);
+    expect(this.store.getActions()[0]).to.eql(expectedActions[0]);
+    this.store.dispatch(action);
+    expect(this.store.getActions()[1]).to.eql(expectedActions[1]);
   });
 });


### PR DESCRIPTION
When filtering, sorting, page or rows on page is changed, the grid is not unnecessarily rendered before requested data is received.