### PR TITLE
Fix extraColumn's valueRender

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 * In general follow (https://docs.npmjs.com/getting-started/semantic-versioning) versioning.
 
 ## <next>
+* A small fix in extraColumn's `valueRender` function
 
 ## 8.4.1
 * Updated `@opuscapita/react-floating-select` versions

--- a/src/datagrid/datagrid.component.jsx
+++ b/src/datagrid/datagrid.component.jsx
@@ -777,7 +777,7 @@ class DataGrid extends React.PureComponent {
         columnKey: 'extraColumn',
         cell: rowIndex => (
           <div className="oc-datagrid-extra-column-cell no-row-select">
-            {extraColumn.valueRender(data.get(rowIndex), tabIndex)}
+            {extraColumn.valueRender(data.get(rowIndex), rowIndex)}
           </div>
         ),
         cellEdit: rowIndex => (extraColumn.cellEdit ? extraColumn.cellEdit(rowIndex) : null),


### PR DESCRIPTION
extraColumn's valueRender function was called with tabIndex instead of rowIndex.