### PR TITLE
Add 'isEditing', and 'isCreating' parameters to setData

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 
 ## <next>
 
+## 9.1.7
+* Add 'isEditing', and 'isCreating' parameters to setData
+
 ## 9.1.6
 * Fix context menu to open up if there's no room to open down
 * Refactor context menu to own component

--- a/src/datagrid/datagrid.actions.js
+++ b/src/datagrid/datagrid.actions.js
@@ -250,7 +250,13 @@ export const sortChange = (grid, columns, column, newSort) => (dispatch, getStat
   applySort(grid, columns)(dispatch, getState);
 };
 
-export const setData = (grid, columns, data) => (dispatch, getState) => {
+export const setData = (
+  grid,
+  columns,
+  data,
+  isEditing = false,
+  isCreating = false,
+) => (dispatch, getState) => {
   Utils.checkGridParam(grid);
   Utils.checkColumnsParam(columns);
   const configData = Utils.loadGridConfig(grid, columns);
@@ -264,6 +270,8 @@ export const setData = (grid, columns, data) => (dispatch, getState) => {
     data: immutableData,
     config: configData,
     selectedItems,
+    isEditing,
+    isCreating,
   });
   if (!grid.pagination) {
     applyFilters(grid, columns)(dispatch, getState);

--- a/src/datagrid/datagrid.reducer.js
+++ b/src/datagrid/datagrid.reducer.js
@@ -26,8 +26,8 @@ export default function datagridReducer(state = INITIAL_STATE, action) {
         .setIn([action.id, 'config'], Immutable.fromJS(action.config))
         .setIn([action.id, 'selectedItems'], Immutable.fromJS(action.selectedItems))
         .mergeIn([action.id, 'session'], {
-          isEditing: false,
-          isCreating: false,
+          isEditing: action.isEditing,
+          isCreating: action.isCreating,
           isBusy: false,
         })
         .deleteIn([action.id, 'selectedCell'])


### PR DESCRIPTION
There is an issue that if `setData` and `edit` actions are called in sequence in asynchronous method, the grid scroll will jump to top. Setting `isEditing = true` will fix this.

I don't know if this can cause any unwanted side effects?