### PR TITLE
Add `validateWithGridData` validator type to `createCellValueValidate` function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 * In general follow (https://docs.npmjs.com/getting-started/semantic-versioning) versioning.
 
 ## <next>
+* Add `validateWithGridData` validator type to `createCellValueValidate` function
 
 ## 9.1.8
 * Upgrade packages, fixes error output to console when currency code is unknown with currency componentType

--- a/src/datagrid/datagrid.actions.js
+++ b/src/datagrid/datagrid.actions.js
@@ -615,10 +615,12 @@ export const createCellValueValidate = (grid, rowIndex, keyPath, value, validato
         const params = validator.params ? Object.values(validator.params) : [];
         validationState = validator.validateWithRowData(value, rowData, ...params);
       } else if (validator.validateWithGridData) {
-        const rowData = getState().datagrid.getIn([grid.id, 'createData', rowIndex]);
+        const createData = getState().datagrid.getIn([grid.id, 'createData']);
+        const rowData = createData.get(rowIndex);
         const allData = getState().datagrid.getIn([grid.id, 'allData']);
+        const combinedData = allData.concat(createData);
         const params = validator.params ? Object.values(validator.params) : [];
-        validationState = validator.validateWithGridData(value, rowData, allData, ...params);
+        validationState = validator.validateWithGridData(value, rowData, combinedData, ...params);
       } else {
         const params = validator.params ? Object.values(validator.params) : [];
         validationState = validator.validate(value, ...params);

--- a/src/datagrid/datagrid.actions.js
+++ b/src/datagrid/datagrid.actions.js
@@ -614,6 +614,11 @@ export const createCellValueValidate = (grid, rowIndex, keyPath, value, validato
         const rowData = getState().datagrid.getIn([grid.id, 'createData', rowIndex]);
         const params = validator.params ? Object.values(validator.params) : [];
         validationState = validator.validateWithRowData(value, rowData, ...params);
+      } else if (validator.validateWithGridData) {
+        const rowData = getState().datagrid.getIn([grid.id, 'createData', rowIndex]);
+        const allData = getState().datagrid.getIn([grid.id, 'allData']);
+        const params = validator.params ? Object.values(validator.params) : [];
+        validationState = validator.validateWithGridData(value, rowData, allData, ...params);
       } else {
         const params = validator.params ? Object.values(validator.params) : [];
         validationState = validator.validate(value, ...params);


### PR DESCRIPTION
It's now possible to validate create data with existing grid data.