### PR TITLE
Added node type to selectComponentOptions's label prop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 * In general follow (https://docs.npmjs.com/getting-started/semantic-versioning) versioning.
 
 ## <next>
+* Added node type to selectComponentOptions's label prop
 * Upgrade packages
 
 ## 9.1.24

--- a/src/datagrid/datagrid.props.js
+++ b/src/datagrid/datagrid.props.js
@@ -105,7 +105,7 @@ export const columnShape = shape({
   selectComponentOptions: arrayOf(
     shape({
       value: oneOfType([number, string, bool]).isRequired,
-      label: oneOfType([number, string]).isRequired,
+      label: oneOfType([number, string, node]).isRequired,
     }),
   ),
   selectComponentTranslations: shape({
@@ -198,7 +198,7 @@ export const propTypes = {
       shape({
         // Options data for the react-select components
         value: oneOfType([number, string, bool]).isRequired,
-        label: oneOfType([number, string]).isRequired,
+        label: oneOfType([number, string, node]).isRequired,
       }),
     ),
   ),


### PR DESCRIPTION
The change is made so the warnings are not raised when label of select options is an Icon or other element